### PR TITLE
Integration test for fallocate falling back to dd

### DIFF
--- a/tests/integration_tests/bugs/test_lp1897099.py
+++ b/tests/integration_tests/bugs/test_lp1897099.py
@@ -1,0 +1,39 @@
+""" Integration test for LP #187099
+
+Ensure that if fallocate fails during mkswap that we fall back to using dd
+
+https://bugs.launchpad.net/cloud-init/+bug/1897099
+"""
+
+import pytest
+
+
+USER_DATA = """\
+#cloud-config
+swap:
+  filename: /swap.img
+  size: 10000000
+  maxsize: 10000000
+"""
+
+
+@pytest.mark.user_data(USER_DATA)
+@pytest.mark.lxd_vm
+def test_fallocate_fallback(client):
+    # Setup instance
+    client.execute('swapoff -a')
+    client.execute('rm -r /swap.img')
+    client.execute("echo 'whoops' > /usr/bin/fallocate")
+
+    # Reset instance state
+    client.execute('cloud-init clean --logs && sync')
+    client.instance.restart()
+    client.instance.wait(raise_on_cloudinit_failure=False)
+
+    # Verify
+    log = client.read_from_file('/var/log/cloud-init.log')
+    assert '/swap.img' in client.execute('cat /proc/swaps')
+    assert '/swap.img' in client.execute('cat /etc/fstab')
+    assert 'fallocate swap creation failed, will attempt with dd' in log
+    assert "Running command ['dd', 'if=/dev/zero', 'of=/swap.img'" in log
+    assert 'SUCCESS: config-mounts ran successfully' in log

--- a/tests/integration_tests/bugs/test_lp1900837.py
+++ b/tests/integration_tests/bugs/test_lp1900837.py
@@ -1,0 +1,28 @@
+"""Integration test for LP: #1900836.
+
+This test mirrors the reproducing steps from the reported bug: it changes the
+permissions on cloud-init.log to 600 and confirms that they remain 600 after a
+reboot.
+"""
+import pytest
+
+
+def _get_log_perms(client):
+    return client.execute("stat -c %a /var/log/cloud-init.log")
+
+
+@pytest.mark.sru_2020_11
+class TestLogPermissionsNotResetOnReboot:
+    def test_permissions_unchanged(self, client):
+        # Confirm that the current permissions aren't 600
+        assert "644" == _get_log_perms(client)
+
+        # Set permissions to 600 and confirm our assertion passes pre-reboot
+        client.execute("chmod 600 /var/log/cloud-init.log")
+        assert "600" == _get_log_perms(client)
+
+        # Reboot
+        client.instance.restart()
+
+        # Check that permissions are not reset on reboot
+        assert "600" == _get_log_perms(client)

--- a/tox.ini
+++ b/tox.ini
@@ -169,3 +169,4 @@ markers =
     lxd_container: test will only run in LXD container
     user_data: the user data to be passed to the test instance
     instance_name: the name to be used for the test instance
+    sru_2020_11: test is part of the 2020/11 SRU verification


### PR DESCRIPTION
## Proposed Commit Message
Integration test for fallocate falling back to dd
    
See https://github.com/canonical/cloud-init/pull/585
    
LP: #1897099

## Additional Context
I added a new mark that would allow us to provide a callback for performing setup on an instance before running the verification.

## Test Steps
pytest tests/integration_tests/modules/test_mounts.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
