### PR TITLE
DRAFT: Schema yaml

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -16,21 +16,22 @@ import re
 from cloudinit import gpg
 from cloudinit import log as logging
 from cloudinit import subp, templater, util
-from cloudinit.config.schema import get_meta_doc, validate_cloudconfig_schema
-from cloudinit.config.schemas.apt_configure import (
-    ADD_APT_REPO_MATCH,
-    meta,
-    schema,
+from cloudinit.config.schema import (
+    get_meta_doc,
+    parse_schema_file,
+    validate_cloudconfig_schema,
 )
+from cloudinit.config.schemas.apt_configure import ADD_APT_REPO_MATCH
+
+meta, schema = parse_schema_file("cc_apt_configure")
+__doc__ = get_meta_doc(meta, schema)
+
 
 LOG = logging.getLogger(__name__)
 
 APT_LOCAL_KEYS = "/etc/apt/trusted.gpg"
 APT_TRUSTED_GPG_DIR = "/etc/apt/trusted.gpg.d/"
 CLOUD_INIT_GPG_DIR = "/etc/apt/cloud-init.gpg.d/"
-
-__doc__ = get_meta_doc(meta, schema)
-
 
 # place where apt stores cached repository data
 APT_LISTS = "/var/lib/apt/lists"

--- a/cloudinit/config/cc_byobu.py
+++ b/cloudinit/config/cc_byobu.py
@@ -8,62 +8,17 @@
 
 """Byobu: Enable/disable byobu system wide and for default user."""
 
-from cloudinit import subp, util
-from cloudinit.config.schema import get_meta_doc, validate_cloudconfig_schema
+from pathlib import Path
+
+from cloudinit import safeyaml, subp, util
+from cloudinit.config.schema import (
+    get_meta_doc,
+    parse_schema_file,
+    validate_cloudconfig_schema,
+)
 from cloudinit.distros import ug_util
-from cloudinit.settings import PER_INSTANCE
 
-MODULE_DESCRIPTION = """\
-This module controls whether byobu is enabled or disabled system wide and for
-the default system user. If byobu is to be enabled, this module will ensure it
-is installed. Likewise, if it is to be disabled, it will be removed if
-installed.
-
-Valid configuration options for this module are:
-
-  - ``enable-system``: enable byobu system wide
-  - ``enable-user``: enable byobu for the default user
-  - ``disable-system``: disable byobu system wide
-  - ``disable-user``: disable byobu for the default user
-  - ``enable``: enable byobu both system wide and for default user
-  - ``disable``: disable byobu for all users
-  - ``user``: alias for ``enable-user``
-  - ``system``: alias for ``enable-system``
-"""
-distros = ["ubuntu", "debian"]
-
-meta = {
-    "id": "cc_byobu",
-    "name": "Byobu",
-    "title": "Enable/disable byobu system wide and for default user",
-    "description": MODULE_DESCRIPTION,
-    "distros": distros,
-    "frequency": PER_INSTANCE,
-    "examples": [
-        "byobu_by_default: enable-user",
-        "byobu_by_default: disable-system",
-    ],
-}
-
-schema = {
-    "type": "object",
-    "properties": {
-        "byobu_by_default": {
-            "type": "string",
-            "enum": [
-                "enable-system",
-                "enable-user",
-                "disable-system",
-                "disable-user",
-                "enable",
-                "disable",
-                "user",
-                "system",
-            ],
-        }
-    },
-}
-
+meta, schema = parse_schema_file("cc_byobu")
 __doc__ = get_meta_doc(meta, schema)
 
 

--- a/cloudinit/config/schemas/cc_apt_configure.yaml
+++ b/cloudinit/config/schemas/cc_apt_configure.yaml
@@ -1,0 +1,268 @@
+meta:
+  id: "cc_apt_configure"
+  name: "Apt Configure"
+  title: "Configure apt for the user"
+  description: |
+    This module handles both configuration of apt options and adding
+    source lists.  There are configuration options such as
+    ``apt_get_wrapper`` and ``apt_get_command`` that control how
+    cloud-init invokes apt-get. These configuration options are
+    handled on a per-distro basis, so consult documentation for
+    cloud-init's distro support for instructions on using
+    these config options.
+
+    .. note::
+        To ensure that apt configuration is valid yaml, any strings
+        containing special characters, especially ``:`` should be quoted.
+
+    .. note::
+        For more information about apt configuration, see the
+        ``Additional apt configuration`` example.
+  distros: ["ubuntu", "debian"]
+  frequency: "once-per-instance"
+  examples:
+    - apt:
+        preserve_sources_list: false
+        disable_suites:
+          - $RELEASE-updates
+          - backports
+          - $RELEASE
+          - mysuite
+        primary:
+          - arches:
+              - amd64
+              - i386
+              - default
+            uri: "http://us.archive.ubuntu.com/ubuntu"
+            search:
+              - "http://cool.but-sometimes-unreachable.com/ubuntu"
+              - "http://us.archive.ubuntu.com/ubuntu"
+            search_dns: false
+          - arches:
+              - s390x
+              - arm64
+            uri: "http://archive-to-use-for-arm64.example.com/ubuntu"
+        security:
+          - arches:
+              - default
+            search_dns: true
+        sources_list: |
+          deb $MIRROR $RELEASE main restricted
+          deb-src $MIRROR $RELEASE main restricted
+          deb $PRIMARY $RELEASE universe restricted
+          deb $SECURITY $RELEASE-security multiverse
+        debconf_selections:
+          set1: the-package the-package/some-flag boolean true
+        conf: |
+          APT {
+              Get {
+                  Assume-Yes 'true';
+                  Fix-Broken 'true';
+              }
+          }
+        proxy: "http://[[user][:pass]@]host[:port]/"
+        http_proxy: "http://[[user][:pass]@]host[:port]/"
+        ftp_proxy: "ftp://[[user][:pass]@]host[:port]/"
+        https_proxy: "https://[[user][:pass]@]host[:port]/"
+        sources:
+          source1:
+            keyid: "keyid"
+            keyserver: "keyserverurl"
+            source: "deb [signed-by=$KEY_FILE] http://<url>/ xenial main"
+          source2:
+            source: "ppa:<ppa-name>"
+          source3:
+            source: "deb $MIRROR $RELEASE multiverse"
+            key: |
+              ------BEGIN PGP PUBLIC KEY BLOCK-------
+              <key data>
+              ------END PGP PUBLIC KEY BLOCK-------"""
+schema:
+  type: "object"
+  properties:
+    apt:
+      type: "object"
+      additionalProperties: false
+      properties:
+        preserve_sources_list:
+          type: "boolean"
+          default: False
+          description: |
+            By default, cloud-init will generate a new sources list in ``/etc/apt/sources.list.d`` based on any
+            changes specified in cloud config. To disable this behavior and preserve the sources list from the
+            pristine image, set ``preserve_sources_list`` to ``true``.
+
+            The ``preserve_sources_list`` option overrides all other config keys that would alter ``sources.list``
+            or ``sources.list.d``, **except** for additional sources to be added to ``sources.list.d``.
+        disable_suites:
+          type: "array"
+          items:
+            type: "string"
+          uniqueItems: true
+          description: |
+            Entries in the sources list can be disabled using ``disable_suites``, which takes a list of suites
+            to be disabled. If the string ``$RELEASE`` is present in a suite in the ``disable_suites`` list,
+            it will be replaced with the release name. If a suite specified in ``disable_suites`` is not
+            present in ``sources.list`` it will be ignored. For convenience, several aliases are provided for
+            ``disable_suites``:
+
+              - ``updates`` => ``$RELEASE-updates``
+              - ``backports`` => ``$RELEASE-backports``
+              - ``security`` => ``$RELEASE-security``
+              - ``proposed`` => ``$RELEASE-proposed``
+              - ``release`` => ``$RELEASE``.
+
+            When a suite is disabled using ``disable_suites``, its entry in ``sources.list`` is not deleted; it
+            is just commented out.
+        primary:
+          description: |
+            The primary and security archive mirrors can be specified using the ``primary`` and
+            ``security`` keys, respectively. Both the ``primary`` and ``security`` keys take a list
+            of configs, allowing mirrors to be specified on a per-architecture basis. Each config is a
+            dictionary which must have an entry for ``arches``, specifying which architectures
+            that config entry is for. The keyword ``default`` applies to any architecture not
+            explicitly listed. The mirror url can be specified with the ``uri`` key, or a list of mirrors to
+            check can be provided in order, with the first mirror that can be resolved being selected. This
+            allows the same configuration to be used in different environment, with different hosts used
+            for a local apt mirror. If no mirror is provided by ``uri`` or ``search``, ``search_dns`` may be
+            used to search for dns names in the format ``<distro>-mirror`` in each of the following:
+
+                - fqdn of this host per cloud metadata,
+                - localdomain,
+                - domains listed in ``/etc/resolv.conf``.
+
+            If there is a dns entry for ``<distro>-mirror``, then it is assumed that there is a distro mirror
+            at ``http://<distro>-mirror.<domain>/<distro>``. If the ``primary`` key is defined, but not the
+            ``security`` key, then then configuration for ``primary`` is also used for ``security``.
+            If ``search_dns`` is used for the ``security`` key, the search pattern will be
+            ``<distro>-security-mirror``.
+
+            Each mirror may also specify a key to import via any of the following optional keys:
+
+                - ``keyid``: a key to import via shortid or fingerprint.
+                - ``key``: a raw PGP key.
+                - ``keyserver``: alternate keyserver to pull ``keyid`` key from.
+
+            If no mirrors are specified, or all lookups fail, then default mirrors defined in the datasource
+            are used. If none are present in the datasource either the following defaults are used:
+
+                - ``primary`` => ``http://archive.ubuntu.com/ubuntu``.
+                - ``security`` => ``http://security.ubuntu.com/ubuntu``
+          type: "array"
+          items: &MIRROR_PROPERTY
+            type: "object"
+            additionalProperties: false
+            required: ["arches"]
+            properties:
+              arches:
+                type: "array"
+                items:
+                  type: "string"
+                minItems: 1
+              uri:
+                type: "string"
+                format: "uri"
+              search:
+                type: "array"
+                items:
+                  type: "string"
+                  format: "uri"
+                minItems: 1
+              search_dns:
+                type: "boolean"
+              keyid:
+                type: "string"
+              key:
+                type: "string"
+              keyserver:
+                type: "string"
+        security:
+          description: "Please refer to the primary config documentation"
+          type: "array"
+          items:
+            <<: *MIRROR_PROPERTY
+        add_apt_repo_match:
+          type: "string"
+          default: '^[\w-]+:\w'
+          description: |
+            All source entries in ``apt-sources`` that match regex in ``add_apt_repo_match`` will be added to
+            the system using ``add-apt-repository``. If ``add_apt_repo_match`` is not specified, it
+            defaults to ``[\w-]+:\w``.
+        debconf_selections:
+          type: "object"
+          items:
+            type: "string"
+          description: |
+            Debconf additional configurations can be specified as a dictionary under the ``debconf_selections`` config
+            key, with each key in the dict representing a different set of configurations. The value of each key
+            must be a string containing all the debconf configurations that must be applied. We will bundle
+            all of the values and pass them to ``debconf-set-selections``. Therefore, each value line
+            must be a valid entry for ``debconf-set-selections``, meaning that they must possess for distinct fields:
+
+            ``pkgname question type answer``
+
+            Where:
+
+                - ``pkgname`` is the name of the package.
+                - ``question`` the name of the questions.
+                - ``type`` is the type of question.
+                - ``answer`` is the value used to ansert the question.
+
+            For example:
+            ``ippackage ippackage/ip string 127.0.01``
+        sources_list:
+          type: "string"
+          description: |
+            Specifies a custom template for rendering ``sources.list`` . If no ``sources_list`` template
+            is given, cloud-init will use sane default. Within this template, the following strings will be
+            replaced with the appropriate values:
+
+                - ``$MIRROR``
+                - ``$RELEASE``
+                - ``$PRIMARY``
+                - ``$SECURITY``
+                - ``$KEY_FILE``
+        conf:
+          type: "string"
+          description: |
+            Specify configuration for apt, such as proxy configuration. This configuration is specified as a
+            string. For multiline apt configuration, make sure to follow yaml syntax.
+        https_proxy:
+          type: "string"
+          description: More convenient way to specify https apt proxy. https proxy url is specified in the format ``https://[[user][:pass]@]host[:port]/``.
+        http_proxy:
+          type: string
+          description: More convenient way to specify http apt proxy. http proxy url is specified in the format ``http://[[user][:pass]@]host[:port]/``.
+        proxy:
+          type: string
+          description: Alias for defining a http apt proxy.
+        ftp_proxy:
+          type: string
+          description: More convenient way to specify ftp apt proxy. ftp proxy url is specified in the format ``ftp://[[user][:pass]@]host[:port]/``.
+        sources:
+          type: "object"
+          items:
+            type: "string"
+          description: |
+            Source list entries can be specified as a dictionary under the ``sources`` config key, with
+            each key in the dict representing a different source file. The key of each source entry will be used
+            as an id that can be referenced in other config entries, as well as the filename for the source's
+            configuration under ``/etc/apt/sources.list.d``. If the name does not end with ``.list``, it will
+            be appended. If there is no configuration for a key in ``sources``, no file will be written, but
+            the key may still be referred to as an id in other ``sources`` entries.
+
+            Each entry under ``sources`` is a dictionary which may contain any of the following optional keys:
+
+                - ``source``: a sources.list entry (some variable replacements apply).
+                - ``keyid``: a key to import via shortid or fingerprint.
+                - ``key``: a raw PGP key.
+                - ``keyserver``: alternate keyserver to pull ``keyid`` key from.
+                - ``filename``: specify the name of the .list file
+
+            The ``source`` key supports variable replacements for the following strings:
+
+                - ``$MIRROR``
+                - ``$PRIMARY``
+                - ``$SECURITY``
+                - ``$RELEASE``
+                - ``$KEY_FILE``"""

--- a/cloudinit/config/schemas/cc_byobu.yaml
+++ b/cloudinit/config/schemas/cc_byobu.yaml
@@ -1,0 +1,39 @@
+meta:
+  id: "cc_byobu"
+  name: "Byobu"
+  title: "Enable/Disable byobu system wide or for default user"
+  description: |
+    This module controls whether byobu is enabled or disabled system wide and for
+    the default system user. If byobu is to be enabled, this module will ensure it
+    is installed. Likewise, if it is to be disabled, it will be removed if
+    installed.
+
+    Valid configuration options for this module are:
+
+      - ``enable-system``: enable byobu system wide
+      - ``enable-user``: enable byobu for the default user
+      - ``disable-system``: disable byobu system wide
+      - ``disable-user``: disable byobu for the default user
+      - ``enable``: enable byobu both system wide and for default user
+      - ``disable``: disable byobu for all users
+      - ``user``: alias for ``enable-user``
+      - ``system``: alias for ``enable-system``
+  distros: ["ubuntu", "debian"]
+  frequency: "once-per-instance"
+  examples:
+    - byobu_by_default: "enable-user"
+    - byobu_by_default: "disable-system"
+schema:
+  type: "object"
+  properties:
+    byobu_by_default:
+      type: "string"
+      enum:
+        - "enable-system"
+        - "enable-user"
+        - "disable-system"
+        - "disable-user"
+        - "enable"
+        - "disable"
+        - "user"
+        - "system"

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -228,7 +228,11 @@ class TestCloudConfigExamples:
         """For a given example in a config module we test if it is valid
         according to the unified schema of all config modules
         """
-        config_load = safe_load(example)
+        try:
+            config_load = safe_load(example)
+        except AttributeError:
+            # Dictionary of examples was defined directly in schema yaml
+            config_load = example
         validate_cloudconfig_schema(
             config_load, self.schema[schema_id], strict=True
         )

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -10,6 +10,7 @@ from copy import copy
 from pathlib import Path
 from textwrap import dedent
 
+import jsonschema
 import pytest
 from yaml import safe_load
 


### PR DESCRIPTION
This is a draft to discuss a POC. Do not merge.

I took Grant's suggestion and tried defining our schema in a yaml file. I think this looks a lot cleaner, but I'd like to get buy-in first. I like that we don't need to define it in python and/or worry about indentation or long lines. Some cons to think about:
* We should probably define a separate schema for our 'meta' definition. Before we could rely on python imports for distros or frequency. Without that, we should define a meta schema (as opposed to a metaschema (yo dawg)) to ensure all the values for those definitions are valid.
* Some schemas (e.g., apt) define sections to be reused and/or templated. Reuse is possible via [json schema](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.2.4), and templating is possible via  [yaml](https://yaml.org/type/merge.html), but that'll add some complexity and that conversion could be error prone.
* We'll have to rewrite all of our currently written schemas, which will be more work.

We could also remove the 'meta' definition entirely and shift the non-schema keys to being top-level